### PR TITLE
Adding logarithmic retryable error type

### DIFF
--- a/retro_test.go
+++ b/retro_test.go
@@ -294,3 +294,39 @@ func TestWrapRetryableNil(t *testing.T) {
 		t.Errorf("error was %s, expected nil", err1.Error())
 	}
 }
+
+func TestBackoffRetryableError(t *testing.T) {
+	baseErr := errors.New("foobar")
+	maxAttempts := 10
+	err := NewBackoffRetryableError(baseErr, maxAttempts)
+	if err == nil {
+		t.Error("retryable error was nil")
+	}
+	if maxAttempts != err.MaxAttempts() {
+		t.Errorf("Incorrect MaxAttempts returned, expected %d, received %d", maxAttempts, err.MaxAttempts())
+	}
+}
+
+func TestStaticRetryableError(t *testing.T) {
+	baseErr := errors.New("foobar")
+	maxAttempts := 10
+	err := NewStaticRetryableError(baseErr, maxAttempts, 4)
+	if err == nil {
+		t.Error("retryable error was nil")
+	}
+	if maxAttempts != err.MaxAttempts() {
+		t.Errorf("Incorrect MaxAttempts returned, expected %d, received %d", maxAttempts, err.MaxAttempts())
+	}
+}
+
+func TestLogarithmicRetryableError(t *testing.T) {
+	baseErr := errors.New("foobar")
+	maxAttempts := 10
+	err := NewLogarithmicRetryableError(baseErr, maxAttempts, 1, 2, 3)
+	if err == nil {
+		t.Error("retryable error was nil")
+	}
+	if maxAttempts != err.MaxAttempts() {
+		t.Errorf("Incorrect MaxAttempts returned, expected %d, received %d", maxAttempts, err.MaxAttempts())
+	}
+}


### PR DESCRIPTION
This change adds a new type of retryable error which uses a logarithmic function to determine sleep time between retry attemtps. This is ideal for situations where a specific resources is becoming available but in an unknown time between 0 and N seconds. With a logarithmic function determining the sleep time your code can retry at at tapering rate, initially increasing significantly, and then increasing at a slower and slower rate.